### PR TITLE
Add setting for limitting iGlobalTime

### DIFF
--- a/screensaver.shadertoy/resources/language/English/strings.po
+++ b/screensaver.shadertoy/resources/language/English/strings.po
@@ -112,3 +112,6 @@ msgctxt "#30023"
 msgid "Cellular"
 msgstr ""
 
+msgctxt "#32000"
+msgid "Workaround low precision GPU (f.e. Mali). Enable this if presets are slow or stuck."
+msgstr ""

--- a/screensaver.shadertoy/resources/settings.xml
+++ b/screensaver.shadertoy/resources/settings.xml
@@ -1,3 +1,4 @@
 <settings>
   <setting id="preset" label="30000" type="select" lvalues="30100|30001|30002|30023|30003|30022|30004|30005|30006|30007|30008|30009|30010|30011|30012|30013|30014|30015|30016|30017|30018|30019|30020|30021" default="0"/>
+  <setting id="limit_time_resolution" label="32000" type="bool" default="false"/>
 </settings>


### PR DESCRIPTION
This is for GPUs with poor shader units which only have a limited precision in floats.
