### PR TITLE
Fix xbmc_scr_dll.h include path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "kodi/xbmc_scr_dll.h"
+#include "xbmc_scr_dll.h"
 #if defined(HAS_GLES)
 #include <GLES2/gl2.h>
 #include <EGL/egl.h>


### PR DESCRIPTION
This PR changes the include path for `xbmc_scr_dll.h` to make it easier to build this binary addon when Kodi's app name have been changed.

`${KODI_INCLUDE_DIR}` @ https://github.com/popcornmix/screensaver.shadertoy/blob/master/CMakeLists.txt#L29 already points to the `kodi` folder and to an app-named include folder in my case.